### PR TITLE
Apply Mapbox Style to layers

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@types/react": "^16.9.38",
     "@types/react-dom": "^16.9.8",
     "ol": "^6.3.1",
+    "ol-mapbox-style": "^6.1.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1",

--- a/src/components/mapcomponent.tsx
+++ b/src/components/mapcomponent.tsx
@@ -14,6 +14,7 @@ import { transform } from 'ol/proj';
 import { Fill, Stroke, Style } from 'ol/style';
 import CircleStyle from 'ol/style/Circle';
 import MVT from 'ol/format/MVT';
+import { applyStyle } from 'ol-mapbox-style';
 
 import OverlayPositioning from 'ol/OverlayPositioning';
 import { Basemaps, GeometryType, Tileset } from '../types';
@@ -205,7 +206,11 @@ function MapComponent({ basemaps, tilesets }: MapProps) {
           style,
         });
         vectorLayer.set('name', tileset.name);
-        olMap.addLayer(vectorLayer);
+        if (tileset.style) {
+          applyStyle(vectorLayer, tileset.style, layerName).then(() => olMap.addLayer(vectorLayer));
+        } else {
+          olMap.addLayer(vectorLayer);
+        }
       });
     });
   }, [olMap, tilesets, removeOldLayers]);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,9 +20,16 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react"
+    "jsx": "react",
+    "baseUrl": "./"
   },
   "include": [
-    "src"
-  ]
+    "src",
+    "node_modules/ol-mapbox-style/**/*"
+  ],
+  "typeAcquisition": {
+    "exclude": [
+      "ol-mapbox-style"
+    ]
+  }
 }


### PR DESCRIPTION
Apply style from tileset.style if available using ol-mapbox-style.

Resolves #3.

Currently lodging and attractions have custom styles.